### PR TITLE
Update settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,7 @@
 
 # General Repository Configuration
 repository:
-  name: docs
+  name: reference
   description: A documentation viewer for Enso's in-language documentation.
   homepage: https://enso.org
   topics: enso, documentation, viewer


### PR DESCRIPTION
Renaming this repository due to our use of an organisation page on github pages. `enso-org.github.io` means that all repositories with github pages enabled on this org appear as a subdirectory on that site, so this repo is currently `dev.enso.org/docs`, which is the directory we serve the devdocs from. This will change it to live at `dev.enso.org/reference`. We'll have to change this pattern because we don't want all github pages on this org being in the dev docs, but that's a future problem. 